### PR TITLE
Add gendered pronouns to sexism.js

### DIFF
--- a/lib/rule/sexism.js
+++ b/lib/rule/sexism.js
@@ -5,7 +5,12 @@ module.exports = defineRules;
 var genderWords = [
     'boy', 'boys', 'bro', 'bros', 'guy', 'guys', 'male', 'man', 'men',
     'female', 'girl', 'girls', 'lady', 'ladies', 'woman', 'women', 'he',
-    'she', 'his', 'her', 'him', 'chick', 'chicks', 'dude', 'dudes'
+    'she', 'his', 'her', 'him', 'chick', 'chicks', 'dude', 'dudes',
+    'mom', 'dad', 'mother', 'mothers', 'father', 'fathers', 'wife', 'wives',
+    'husband', 'husbands', 'grandma', 'grandmas', 'grandpa', 'grandpas', 
+    'grandmother', 'grandmothers', 'granny', 'grannies', 'grandfather',
+    'grandfathers', 'mum', 'mums', 'mommy', 'mommies', 'momma', 'mommas',
+    'papa', 'papas', 'gentleman', 'gentlemen'
 ];
 
 function defineRules (linter) {


### PR DESCRIPTION
Oftentimes the mention of gender is more subtle (in terms of pronoun choice) rather than explicitly saying "a woman" or similar.
