### PR TITLE
add ability to enable custom rules at linter creation

### DIFF
--- a/lib/joblint.js
+++ b/lib/joblint.js
@@ -4,9 +4,16 @@ var createLinter = require('./linter');
 
 module.exports = joblint;
 
-function joblint (body) {
+function joblint (body, rules) {
     var linter = createLinter();
     injectRulesIntoLinter(linter);
+    if (Array.isArray(rules)) {
+        for (var i = rules.length - 1; i >= 0; i -= 1) {
+            rules[i](linter);
+        }
+    } else if (typeof rules === 'function') {
+        rules(linter);
+    }
     return linter.lint(body);
 }
 

--- a/test/unit/custom-rules.js
+++ b/test/unit/custom-rules.js
@@ -13,7 +13,7 @@ describe('custom rules', function () {
             done();
         });
     });
-    it('should be possible to add multiple ad linter creation', function () {
+    it('should be possible to add multiple at linter creation', function () {
         var added = 0;
 
         function inc(linter) {

--- a/test/unit/custom-rules.js
+++ b/test/unit/custom-rules.js
@@ -1,0 +1,28 @@
+/* jshint maxstatements: false, maxlen: false */
+/* global describe, it */
+'use strict';
+
+var assert = require('proclaim');
+var joblint = require('../../lib/joblint');
+
+describe('custom rules', function () {
+    it('should be possible to add at linter creation', function (done) {
+        joblint('hello world', function (linter) {
+            assert.ok(linter);
+            assert.isFunction(linter.addRule);
+            done();
+        });
+    });
+    it('should be possible to add multiple ad linter creation', function () {
+        var added = 0;
+
+        function inc(linter) {
+            assert.ok(linter);
+            assert.isFunction(linter.addRule);
+            added += 1;
+        }
+
+        joblint('hello world', [ inc, inc, inc, inc ]);
+        assert.equal(added, 4);
+    });
+});


### PR DESCRIPTION
i wasn't able to add tests to `/test/unit/joblint.js` without massive changes, so i put them in a separate file

this somewhat touches on a discussion held in #6