### PR TITLE
Detect possible empty input stream

### DIFF
--- a/bin/joblint.js
+++ b/bin/joblint.js
@@ -62,7 +62,11 @@ function runCommandOnFile (fileName) {
 }
 
 function runCommandOnStdIn () {
-    captureStdIn(handleInputSuccess);
+    if (isTty(process.stdin)) {
+        handleInputFailure('Input stream not detected');
+    } else {
+        captureStdIn(handleInputSuccess);
+    }
 }
 
 function handleInputFailure (msg) {
@@ -84,4 +88,8 @@ function captureStdIn (done) {
     process.stdin.on('end', function () {
         done(data);
     });
+}
+
+function isTty (stream) {
+    return true === stream.isTTY;
 }


### PR DESCRIPTION
Using `process.stdin.isTTY`, detect whether streaming input is even possible. If the process is a TTY, then nothing has been piped into the command. If the process is not a TTY, then it is _possible_, but not definite, that input is being streamed.
