### PR TITLE
Update reporter loading

### DIFF
--- a/bin/joblint.js
+++ b/bin/joblint.js
@@ -28,7 +28,9 @@ function loadReporter (reporter) {
 
 function getReporter (reporter) {
     var path = getLocalReporterPath(reporter) || getModuleReporterPath(reporter);
-    return require(path);
+    if (path) {
+        return require(path);
+    }
 }
 
 function getLocalReporterPath (reporter) {


### PR DESCRIPTION
Silently catching all exceptions from loading reporters can result in a potentially misleading error message.
This patch fixes the case where the reporter exists but it's internal dependencies don't (or another exception was thrown during load).

My OCD still can't cope with the empty `catch`es, but I guess I just need to chill out ;)
