### PR TITLE
Browser Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,41 +1,59 @@
 {
-    "name": "joblint",
-    "version": "1.3.0",
-
-    "description": "Test tech job specs for issues with sexism, culture, expectations, and recruiter fails.",
-    "keywords": [ "job", "lint" ],
-    "author": "Rowan Manning (http://rowanmanning.com/)",
-    "license": "MIT",
-
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/rowanmanning/joblint.git"
-    },
-    "homepage": "https://github.com/rowanmanning/joblint",
-    "bugs": "https://github.com/rowanmanning/joblint/issues",
-
-    "engines": {
-        "node": ">=0.10"
-    },
-    "dependencies": {
-        "chalk": "0.2",
-        "commander": "~2.0",
-        "dedupe": "~0.2",
-        "flatten": "~0.0",
-        "pad-component": "~0.0",
-        "slugg": "~0.1",
-        "wordwrap": "~0.0"
-    },
-    "devDependencies": {
-        "jshint": "~2.1",
-        "mocha": "~1.13",
-        "mockery": "~1.4",
-        "proclaim": "~2.0",
-        "sinon": "~1.7"
-    },
-
-    "main": "./lib/joblint.js",
-    "bin": {
-        "joblint": "./bin/joblint.js"
-    }
+  "name": "joblint",
+  "version": "1.3.0",
+  "description": "Test tech job specs for issues with sexism, culture, expectations, and recruiter fails.",
+  "keywords": [
+    "job",
+    "lint"
+  ],
+  "author": "Rowan Manning (http://rowanmanning.com/)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rowanmanning/joblint.git"
+  },
+  "homepage": "https://github.com/rowanmanning/joblint",
+  "bugs": "https://github.com/rowanmanning/joblint/issues",
+  "engines": {
+    "node": ">=0.10"
+  },
+  "scripts": {
+    "build-browser": "browserify -r ./lib/joblint.js -s joblint > joblint.js",
+    "test-browser": "testling"
+  },
+  "testling": {
+    "files": "test/unit/*.js",
+    "harness": "mocha-bdd",
+    "browsers": [
+      "ie/9..10",
+      "ff/latest..nightly",
+      "chrome/latest..canary",
+      "opera/latest..next",
+      "safari/latest",
+      "ipad/latest",
+      "android/latest"
+    ]
+  },
+  "dependencies": {
+    "chalk": "0.2",
+    "commander": "~2.0",
+    "dedupe": "~0.2",
+    "flatten": "~0.0",
+    "pad-component": "~0.0",
+    "slugg": "~0.1",
+    "wordwrap": "~0.0"
+  },
+  "devDependencies": {
+    "jshint": "~2.1",
+    "mocha": "~1.13",
+    "mockery": "~1.4",
+    "proclaim": "~2.0",
+    "sinon": "~1.7",
+    "browserify": "~2.34.3",
+    "testling": "~1.5.3"
+  },
+  "main": "./lib/joblint.js",
+  "bin": {
+    "joblint": "./bin/joblint.js"
+  }
 }


### PR DESCRIPTION
I quickly ran the code through `browserify` to make that working in the browser.

**Good Thing**

``` bash
npm install
npm run build-browser
echo "<script src=joblint.js></script><script>console.log(joblint(prompt('Copy/paste a spec here')))</script>" > demo.html && open demo.html
```

And look at the result in the console.
I had the same results as the Node execution.

**Bad Thing**

For some reason, the mocks make things complicated test. I haven't spent many time on the problem so it might be obvious but well.

``` bash
npm run test-browser
```
