### PR TITLE
'Happy Hour' variations were accidentally dropped.

### DIFF
--- a/lib/rule/bubble.js
+++ b/lib/rule/bubble.js
@@ -16,6 +16,7 @@ var temptations = [
     /brewskis?/,
     'coffee',
     'foosball',
+    /happy\s*hours?/,
     /keg(?:erator)?s?/,
     /lagers?/,
     /nerf\s*guns?/,


### PR DESCRIPTION
Variations on 'happy hour' were dropped accidentally during the conversion to use regexes.
