### PR TITLE
Scunthorpe fix

### DIFF
--- a/lib/rule/expectations.js
+++ b/lib/rule/expectations.js
@@ -3,7 +3,7 @@
 module.exports = defineRules;
 
 var competitivePhrases = [
-    'compete(?!nt|nce|ncies)',
+    'compete(?!nt|nce|ncy|ncies)',
     'competition',
     /competitive(?!\ssalary|\spay)/,
     'cutting edge',


### PR DESCRIPTION
fixed a substring issue where "competence" and some variations was getting flagged by the "compete" rule. Checked make lint and make test first :)
