### PR TITLE
Generalize some rules

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -87,7 +87,7 @@ module.exports = [
     // Mention of facial hair
     {
         name: 'Mention of facial hair',
-        reason: 'The use of "grizzled" or "bearded" indicates that you\'re only looking for male developers.',
+        reason: 'The use of "grizzled" or "bearded" indicates that you\'re only looking for male employees.',
         solution: 'Remove these words.',
         level: 'error',
         increment: {
@@ -144,7 +144,7 @@ module.exports = [
     // Use of dumb job titles
     {
         name: 'Use of dumb job titles',
-        reason: 'Referring to tech people as Ninjas or similar devalues the work that they do and shows a lack of respect and professionalism. It\'s also rather cliched and can be an immediate turn-off to many people.',
+        reason: 'Referring to people as ninjas or similar devalues the work that they do and shows a lack of respect and professionalism. It\'s also rather cliched and can be an immediate turn-off to many people.',
         solution: 'Consider what you\'re really asking for in an applicant and articulate this in the job post.',
         level: 'warning',
         increment: {
@@ -271,10 +271,12 @@ module.exports = [
             'bugger',
             'cunt',
             'damn',
-            'fuck(er|ing)?',
+            'fuck(er|ing|ed|s)?',
             'piss(ing)?',
             'shit',
-            'motherfuck(ers?|ing)'
+            'motherfuck(ers?|ing)',
+            'tits?',
+            'blowjob'
         ]
     },
 
@@ -282,7 +284,7 @@ module.exports = [
     // Use of "visionary" terminology
     {
         name: 'Use of "visionary" terminology',
-        reason: 'Terms like "blue sky" and "enlightened" often indicate that a non technical person (perhaps a CEO or stakeholder) has been involved in writing the post. Be down-to-earth, and explain things in plain English.',
+        reason: 'Terms like "blue sky" and "enlightened" often indicate that a higher-up (perhaps a CEO or stakeholder) has been involved in writing the post. Be down-to-earth, and explain things in plain English.',
         solution: 'Reword these phrases, say what you actually mean.',
         level: 'warning',
         increment: {


### PR DESCRIPTION
I didn't end up actually removing any rules - I figure if a job posting is unrelated than the more tech-related rules just won't trigger.

I tried to generalize the text of rules to make them more broadly applicable.